### PR TITLE
Make notifications mechanism more flexible

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,11 @@ You can turn on inactivity reminds, which are will be send when there's no curre
 
 You can also change notification title string and body format string.
 
+The body format string supports customizable formatters (see `org-clock-reminder-formatters`), by default `%c` is the clocked-in time, and `%h` is the current header.
+
 ```emacs-lisp
 (setq org-clock-reminder-notification-title "Productivity notification"
-      org-clock-reminder-format-string "You worked for %s on<br/>%s")
+      org-clock-reminder-format-string "You worked for %c on<br/>%h")
 ```
 
 If you have turned on inactivity notifications, you can also set inactivity notification text.
@@ -85,17 +87,6 @@ If you have turned on inactivity notifications, you can also set inactivity noti
 (setq org-clock-reminder-empty-text "No task is being clocked. Close all distracting windows and continue working...")
 ```
     
-If there's not enought customizations for your task, you can set `org-clock-reminder-format` function.
-
-```emacs-lisp
-(setq org-clock-reminder-format (lambda ()
-                                  (if (org-clocking-p)
-                                      (format "%s [%s]"
-                                              org-clock-heading
-                                              (org-duration-from-minutes (org-clock-get-clocked-time)))
-                                    "No task selected")))
-```
-
 You can set icons for clocking and inactivity states with the following parameters.
 
 ```emacs-lisp

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Or if you don't want to see the icons on notifications, you can turn them off.
 (setq org-clock-reminder-show-icons nil)
 ```
 
+Additionally, you can customize how your are notified.  By default the `notifications` library is used, but you may set multiple or alternate notifiers using the hook `org-clock-reminder-notifiers`, with each function taking title and message arguments.
+
 ## Contributions
 
 Feel free to send pull requests, feature requests, bug reports or fixes. Also I'd like to keep this package as simple as it can be.


### PR DESCRIPTION
I'd like to make the notifications mechanism a bit more flexible.  Among other things:

 - Allow for multiple notification methods by default
 - Improve customizability of formatting (using `format-spec`)